### PR TITLE
Fix private information disclosure

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,7 @@ end
 
 def check_destination
   unless Dir.exist? CONFIG["destination"]
-    sh "git clone https://#{ENV['GIT_NAME']}:#{ENV['GH_TOKEN']}@github.com/#{CONFIG["github_user"]}/#{CONFIG["destination_repo"]}.git #{CONFIG["destination"]}"
+    sh "git clone https://$GIT_NAME:$GH_TOKEN@github.com/#{CONFIG["github_user"]}/#{CONFIG["destination_repo"]}.git #{CONFIG["destination"]}"
   end
 end
 
@@ -185,8 +185,8 @@ namespace :site do
 
     # Configure git if this is run in Travis CI
     if ENV["TRAVIS"]
-      sh "git config --global user.name '#{ENV['GIT_NAME']}'"
-      sh "git config --global user.email '#{ENV['GIT_EMAIL']}'"
+      sh "git config --global user.name '$GIT_NAME'"
+      sh "git config --global user.email '$GIT_EMAIL'"
       sh "git config --global push.default simple"
     end
 


### PR DESCRIPTION
Travis-CI will log every command and in order to avoid information disclosure the command should not contain plain text data.

With this patch the log will look like:
```
** Execute site:deploy
git config --global user.name '$GIT_NAME'
git config --global user.email '$GIT_EMAIL'
git config --global push.default simple
git clone https://$GIT_NAME:$GH_TOKEN@github.com/[...]
```

and without it:

```
** Execute site:deploy
git config --global user.name 'm....r'
git config --global user.email '....@martinfenner.org'
git config --global push.default simple
git clone https://m.....r:14.....................f8@github.com/openingscience/openingscience.github.io.git ../openingscience.github.io/
```

Thanks,
Alex